### PR TITLE
add missing readyState

### DIFF
--- a/src/highlightjs-line-numbers.js
+++ b/src/highlightjs-line-numbers.js
@@ -36,7 +36,7 @@
     }
 
     function initLineNumbersOnLoad (options) {
-        if (d.readyState === 'complete') {
+        if (d.readyState === 'interactive' || d.readyState === 'complete') {
             documentReady(options);
         } else {
             w.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
If highlightjs-line-numbers is run between the the DOMContentLoaded and Load state, the existing code will add an event listener that will never run because the event has already passed. This fixes this particular problem by also accounting for the interactive ready state.